### PR TITLE
upgrade AWS-CLI version

### DIFF
--- a/aws-assume-role/config.yml
+++ b/aws-assume-role/config.yml
@@ -3,7 +3,7 @@ description: |
   Assumes an AWS role and exports temporary credentials
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.9
+  aws-cli: circleci/aws-cli@2.0.0
       
 commands:
     assume_role:


### PR DESCRIPTION
Upgraded AWS-CLI version as only version 2 supports python 2.7, see here:
https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/