### PR TITLE
add ci intergration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,51 @@
+version: 2.1
+
+orbs:
+  cli: circleci/circleci-cli@0.1
+
+jobs:
+  validate:
+    executor: cli/default
+    steps:
+      - checkout
+      - run:
+          name: Validate orb
+          command: circleci orb validate aws-assume-role/config.yml
+
+  publish-dev:
+    executor: cli/default
+    steps:
+      - checkout
+      - run:
+          name: Publish dev version
+          command: circleci orb publish aws-assume-role/config.yml lbh-hackit/aws_assume_role@dev:${CIRCLE_SHA1}
+
+  publish-production:
+    executor: cli/default
+    steps:
+      - checkout
+      - run:
+          name: Publish dev version
+          command: circleci orb publish aws-assume-role/config.yml lbh-hackit/aws_assume_role@dev:${CIRCLE_SHA1}
+      - run:
+          name: Promote to production (patch)
+          command: circleci orb publish promote lbh-hackit/aws_assume_role@dev:${CIRCLE_SHA1} patch
+
+workflows:
+  validate-and-release:
+    jobs:
+      - validate
+      - publish-dev:
+          context: circleci-orb-publishing
+          requires:
+            - validate
+          filters:
+            branches:
+              only: development
+      - publish-production:
+          context: circleci-orb-publishing
+          requires:
+            - validate
+          filters:
+            branches:
+              only: main

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: [--fix=lf]
+      - id: check-yaml
+      - id: check-merge-conflict
+
+  - repo: https://github.com/gitguardian/ggshield
+    rev: v1.47.0
+    hooks:
+      - id: ggshield

--- a/README.md
+++ b/README.md
@@ -1,8 +1,62 @@
-# Custom CircleCI orbs created by LBH 
+# CircleCI Orbs — LBHackney-IT
 
-CircleCI LBH namespace: LINK TBC
+CircleCI namespace: [lbh-hackit](https://circleci.com/developer/orbs?query=lbh-hackit)
 
-# AWS assume role
+## Orbs
 
-The purpose of this orb is to allow projects, which are being deployed via CircleCI, to assume an AWS role if they need to interact with AWS resources.  By using AWS role assumption, we are compliant with the current best security practices. 
+### aws-assume-role
 
+[lbh-hackit/aws_assume_role](https://circleci.com/developer/orbs/orb/lbh-hackit/aws_assume_role)
+
+Assumes an AWS IAM role from within a CircleCI pipeline and exports temporary credentials for use in subsequent
+steps. This avoids storing long-lived AWS keys in environment variables, keeping deployments compliant with
+current security best practices.
+
+#### Usage
+
+```yaml
+orbs:
+  aws_assume_role: lbh-hackit/aws_assume_role@0.1.1
+
+commands:
+  assume-role-and-persist-workspace:
+    parameters:
+      aws-account:
+        type: string
+    steps:
+      - checkout
+      - aws_assume_role/assume_role:
+          account: <<parameters.aws-account>>
+          profile_name: default
+          role: LBH_Circle_CI_Deployment_Role
+      - persist_to_workspace:
+          root: /home/circleci
+          paths:
+            - .aws
+```
+
+#### Parameters
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `account` | string | — | AWS account ID to assume the role in |
+| `role` | string | — | IAM role name to assume |
+| `profile_name` | string | `default` | AWS profile name to write credentials to |
+| `access_key_id` | env_var_name | `AWS_ACCESS_KEY_ID` | Env var holding the IAM user access key |
+| `secret_access_key` | env_var_name | `AWS_SECRET_ACCESS_KEY` | Env var holding the IAM user secret key |
+
+#### Prerequisites
+
+- `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` must be available in the job via a CircleCI context
+- A `.circleci/config` file must exist in the repository — this is copied to `~/.aws/config` to set the AWS region
+- `jq` must be available on the executor image
+
+## Releasing
+
+Releases are automated via the CircleCI pipeline:
+
+- **Merge to `development`** — publishes a dev version (`@dev:<sha>`) for testing in consuming pipelines
+- **Merge to `main`** — promotes to a new production patch release
+
+The pipeline requires an `circleci-orb-publishing` context in the CircleCI org settings containing a `CIRCLECI_CLI_TOKEN`
+with namespace admin access for `lbh-hackit`.

--- a/aws-assume-role/config.yml
+++ b/aws-assume-role/config.yml
@@ -3,8 +3,8 @@ description: |
   Assumes an AWS role and exports temporary credentials
 
 orbs:
-  aws-cli: circleci/aws-cli@0.1.9
-      
+  aws-cli: circleci/aws-cli@5.4.1
+
 commands:
     assume_role:
        description: Installs AWS CLI, setup the IAM user keys and assume specified role
@@ -29,18 +29,17 @@ commands:
             type: string
        steps:
           - aws-cli/install
-          - run: 
+          - run:
               name: Configure CircleCI IAM user
               command: |
                 aws configure set aws_access_key_id $<< parameters.access_key_id >> --profile << parameters.profile_name >> && \
                 aws configure set aws_secret_access_key $<< parameters.secret_access_key >> --profile << parameters.profile_name >> && \
                 cp .circleci/config ~/.aws/config
-              
-          - run: 
+
+          - run:
               name: Assume AWS role and generate temporary credentials
               command: |
                 assumed_role=$(aws sts assume-role --role-arn "arn:aws:iam::<< parameters.account >>:role/<< parameters.role >>" --role-session-name "RoleSession1" --profile << parameters.profile_name >>) && \
                 aws configure set aws_access_key_id $(echo $assumed_role | jq .Credentials.AccessKeyId | xargs) --profile << parameters.profile_name >> && \
                 aws configure set aws_secret_access_key $(echo $assumed_role | jq .Credentials.SecretAccessKey | xargs) --profile << parameters.profile_name >> && \
                 aws configure set aws_session_token $(echo $assumed_role | jq .Credentials.SessionToken | xargs) --profile << parameters.profile_name >>
-                


### PR DESCRIPTION
What
--

* Removes the Python 3 runtime requirement from pipelines consuming the aws-assume-role orb. Previously the orb installed AWS CLI v1 via pip, requiring python3-venv before assuming a role. 
* Adds a CircleCI pipeline to automate orb validation and publishing.
